### PR TITLE
chore: release 1.2.28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
         versionCode 1002028
-        versionName "1.2.28-SNAPSHOT"
+        versionName "1.2.28"
         setProperty("archivesBaseName", "${applicationId}-${versionCode}")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "ai.elimu.content_provider"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 1002028
-        versionName "1.2.28"
+        versionCode 1002029
+        versionName "1.2.29-SNAPSHOT"
         setProperty("archivesBaseName", "${applicationId}-${versionCode}")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
         versionCode 1002028
-        versionName "1.2.28-SNAPSHOT"
+        versionName "1.2.28"
         setProperty("archivesBaseName", "utils-${versionName}")
     }
 
@@ -38,7 +38,7 @@ publishing {
         release(MavenPublication) {
             groupId 'ai.elimu.content_provider'
             artifactId 'utils'
-            version '1.2.28-SNAPSHOT'
+            version '1.2.28'
             artifact("${buildDir}/outputs/aar/utils-${version}-release.aar")
         }
     }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 1002028
-        versionName "1.2.28"
+        versionCode 1002029
+        versionName "1.2.29-SNAPSHOT"
         setProperty("archivesBaseName", "utils-${versionName}")
     }
 
@@ -38,7 +38,7 @@ publishing {
         release(MavenPublication) {
             groupId 'ai.elimu.content_provider'
             artifactId 'utils'
-            version '1.2.28'
+            version '1.2.29-SNAPSHOT'
             artifact("${buildDir}/outputs/aar/utils-${version}-release.aar")
         }
     }


### PR DESCRIPTION
https://github.com/elimu-ai/content-provider/releases/tag/1.2.28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the application version to reflect a new development iteration (versionCode: 1002029, versionName: 1.2.29-SNAPSHOT).
  - Enhanced consistency in version representation and artifact naming for clearer release status for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->