### PR TITLE
Migrate dependency management to version catalog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,32 +42,32 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.github.elimu-ai:model:model-2.0.80' // See https://jitpack.io/#elimu-ai/model
+    implementation(libs.elimu.model) // See https://jitpack.io/#elimu-ai/model
 
-    implementation 'commons-io:commons-io:2.17.0'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation(libs.commons.io)
+    implementation(libs.material)
 
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment:2.4.2'
-    implementation 'androidx.navigation:navigation-ui:2.4.2'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.legacy.supportv4)
+    implementation(libs.androidx.constraint.layout)
+    implementation(libs.androidx.navigation.fragment)
+    implementation(libs.androidx.navigation.ui)
+    implementation(libs.androidx.lifecycle.extensions)
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.11.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.gson)
 
     // Room components
-    implementation "androidx.room:room-runtime:2.4.2"
-    annotationProcessor "androidx.room:room-compiler:2.4.2"
-    androidTestImplementation "androidx.room:room-testing:2.4.2"
+    implementation(libs.androidx.room.runtime)
+    annotationProcessor(libs.androidx.room.compiler)
+    androidTestImplementation(libs.androidx.room.testing)
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation(libs.junit)
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso)
 }
 
 task ensureCleanRepo {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-elimuModel = "model-2.0.80"
+elimuModel = "model-2.0.83"
 elimuAnalytics = "3.1.27"
 commonsIo = "2.17.0"
 material = "1.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 elimuModel = "model-2.0.80"
-elimuAnalytics = "3.1.27@aar"
+elimuAnalytics = "3.1.27"
 commonsIo = "2.17.0"
 material = "1.5.0"
 retrofit = "2.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,39 @@
+[versions]
+elimuModel = "model-2.0.80"
+elimuAnalytics = "3.1.27@aar"
+commonsIo = "2.17.0"
+material = "1.5.0"
+retrofit = "2.11.0"
+junit = "4.13.2"
+
+legacySupportV4 = "1.0.0"
+constraintLayout = "2.1.3"
+appCompat = "1.4.1"
+navigation = "2.4.2"
+lifecycleExtensions = "2.2.0"
+room = "2.4.2"
+androidXJunit = "1.1.3"
+androidXEspresso = "3.4.0"
+
+[libraries]
+elimu-model = { group = "com.github.elimu-ai", name = "model", version.ref = "elimuModel" }
+elimu-analytics = { group = "com.github.elimu-ai", name = "analytics", version.ref = "elimuAnalytics" }
+commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIo" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appCompat" }
+androidx-legacy-supportv4 = { group = "androidx.legacy", name = "legacy-support-v4", version.ref = "legacySupportV4" }
+androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
+androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigation" }
+androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigation" }
+androidx-lifecycle-extensions = { group = "androidx.lifecycle", name = "lifecycle-extensions", version.ref = "lifecycleExtensions" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunit" }
+androidx-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXEspresso" }
+
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+[plugins]

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -27,8 +27,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.elimu-ai:model:model-2.0.80' // See https://jitpack.io/#elimu-ai/model
-    implementation 'com.github.elimu-ai:analytics:3.1.27@aar' // See https://jitpack.io/#elimu-ai/analytics
+    implementation(libs.elimu.model) // See https://jitpack.io/#elimu-ai/model
+    implementation(libs.elimu.analytics) // See https://jitpack.io/#elimu-ai/analytics
 }
 
 // See https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPublication.html


### PR DESCRIPTION
### Issue Number
* Resolves #144

### Purpose
Currently, our project manages dependencies directly in build.gradle files. To improve scalability and maintainability of our dependency management, we should migrate to version catalogs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated app version details to 1.2.28-SNAPSHOT for consistency.
  - Introduced centralized management for library versions and dependencies.

- **Refactor**
  - Simplified dependency declarations to streamline maintenance and updates.
  - Added a new configuration file for managing library versions and plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->