### PR TITLE
WIP: Move release tasks to separate scripts for better reusability

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -21,3 +21,11 @@ jobs:
         java-version: ${{ matrix.java }}
     - uses: gradle/gradle-build-action@v2
     - run: ./gradlew clean build
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        ./gradlew utils:releasePrepare -PbumpType=patch
+        echo "Release utils done!"
+        

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -25,7 +25,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - run: |
-        ./gradlew utils:releasePrepare -PbumpType=patch
-        echo "Release utils done!"
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      - run: |
+          ./gradlew utils:releasePrepare -PbumpType=patch
+          echo "Release utils done!"
         

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -33,6 +33,10 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - run: |
+          ./gradlew utils:releaseClean
           ./gradlew utils:releasePrepare -PbumpType=patch
+          ./gradlew utils:releasePerform
           echo "Release utils done!"
+          echo "Printing out the release output!"
+          ls -lah ~/.m2/repository/ai/elimu/content_provider/utils/1.2.29
         

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -29,3 +29,8 @@ jobs:
           ./gradlew utils:releasePerform
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - run: |
+          echo "Printing out the release output!"
+          cd ~/.m2/repository/ai/elimu/content_provider/utils/1.2.29
+          ls -lah

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -20,8 +20,12 @@ jobs:
       - run: git config user.name 'Nya Ξlimu'
       - run: git config user.email 'info@elimu.ai'
 
-      - run: ./gradlew releaseClean
-      - run: ./gradlew releasePrepare -PbumpType=patch
-      - run: ./gradlew releasePerform
+      - run: |
+          ./gradlew releaseClean
+          ./gradlew app:releasePrepare -PbumpType=patch
+          ./gradlew app:releasePerform
+          
+          ./gradlew utils:releasePrepare -PbumpType=patch
+          ./gradlew utils:releasePerform
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,69 +115,7 @@ task releaseClean(dependsOn: ensureCleanRepo) {
 //    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
 task releasePrepare(dependsOn: ensureCleanRepo) {
     doLast {
-        def applicationId = android.defaultConfig.applicationId
-        def versionName = android.defaultConfig.versionName
-
-        if (versionName.indexOf("-") > -1) {
-            versionName = versionName.split("-")[0]
-        }
-
-        // Prepare the release commit with the specific tag.
-        String buildText = buildFile.getText()
-        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$versionName'")
-        buildFile.setText(buildText) //replace the build file's text
-        grgit.add(patterns: ['app/build.gradle'])
-        try {
-            grgit.commit(message: "[gradle-release-task] prepare release $applicationId-$versionName")
-        } catch (Exception e) {
-            throw new GradleException("Failed to commit, error:\n $e")
-        }
-        try {
-            grgit.tag.add {
-                name = versionName
-                message = "Release of $versionName"
-            }
-        } catch (Exception e) {
-            throw new GradleException("Failed to tag the repo, error:\n $e")
-        }
-
-        // Set new version name from input parameters.
-        def newVersionName
-        if (project.properties.containsKey("bumpVersion")) {
-            newVersionName = project.properties["bumpVersion"]
-            println "Bumping the version directly (bumpVersion=$newVersionName)"
-        } else if (project.properties.containsKey("bumpType")) {
-            def (major, minor, patch) = versionName.tokenize('.')
-            switch (bumpType) {
-                case "major":
-                    major = major.toInteger() + 1
-                    minor = 0
-                    patch = 0
-                    break
-                case "minor":
-                    minor = minor.toInteger() + 1
-                    break
-                case "patch":
-                    patch = patch.toInteger() + 1
-                    break
-            }
-            newVersionName = "$major.$minor.$patch"
-        } else {
-            throw new GradleException('Either bumpType or bumpVersion parameters should be provided')
-        }
-
-        // Prepare for next development iteration.
-        def versionCode = android.defaultConfig.versionCode
-        def newVersionCode = versionCode + 1
-        println "Bumping versionName from $versionName to $newVersionName"
-        println "Bumping versionCode from $versionCode to $newVersionCode"
-        buildText = buildFile.getText()
-        buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName-SNAPSHOT'")
-        buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
-        buildFile.setText(buildText) //replace the build file's text
-        grgit.add(patterns: ['app/build.gradle'])
-        grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
-        println "Done!"
+        prepareRelease()
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.ajoberstar.grgit'
+apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/clean_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/perform_release.gradle"
 
 android {
     compileSdk 34
@@ -80,33 +83,7 @@ task ensureCleanRepo {
 
 task releaseClean(dependsOn: ensureCleanRepo) {
     doLast {
-        def clean = true
-        def applicationId = android.defaultConfig.applicationId
-
-        String headCommitMessage = grgit.head().shortMessage
-        while (headCommitMessage.contains("[gradle-release-task]")) {
-            clean = false
-            println "Found git commit: $headCommitMessage"
-            if (headCommitMessage.indexOf("$applicationId-") > -1) {
-                def tagName = headCommitMessage.split("$applicationId-")[1]
-                println "Removing the git tag: $tagName"
-                try {
-                    grgit.tag.remove {
-                        names = [tagName]
-                    }
-                } catch (Exception e) {
-                    println "Error while removing git tag:\n $e"
-                }
-            }
-            println "Resetting the git commit permanently!"
-            grgit.reset(commit: "HEAD~1", mode: "hard")
-            headCommitMessage = grgit.head().shortMessage
-
-        }
-        if (clean){
-            println "Repository is already clean"
-        }
-        println "Done!"
+        cleanRelease()
     }
 }
 
@@ -114,7 +91,6 @@ task releaseClean(dependsOn: ensureCleanRepo) {
 //    bumpVersion -> if available will specify new versionName directly and ignores the `bumpType` parameter.
 //    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
 
-apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"
 task releasePrepare(dependsOn: ensureCleanRepo) {
     doLast {
         prepareRelease()
@@ -123,17 +99,6 @@ task releasePrepare(dependsOn: ensureCleanRepo) {
 
 task releasePerform(dependsOn: ensureCleanRepo) {
     doLast {
-        boolean force = false
-        if (project.properties.containsKey("force")) {
-            force = project.properties["force"]
-        }
-        println "Pushing the newest commits to the remote repository (force: $force)"
-        try {
-            grgit.push(force: force, tags: true)
-        } catch (Exception e) {
-            throw new GradleException("Failed to push to the repo,\n" +
-                    " you can try using -Pforce=true parameter to force the push, error: \n$e")
-        }
-        println "Done!"
+        performRelease()
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.ajoberstar.grgit'
 apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"
 apply from: "${rootProject.projectDir}/gradle/clean_release.gradle"
 apply from: "${rootProject.projectDir}/gradle/perform_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/ensure_clean.gradle"
 
 android {
     compileSdk 34
@@ -75,9 +76,7 @@ dependencies {
 
 task ensureCleanRepo {
     doLast {
-        if (!grgit.repository.jgit.status().call().clean) {
-            throw new GradleException('Git status is not clean, please stash your changes!')
-        }
+        ensureClean()
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,6 +113,8 @@ task releaseClean(dependsOn: ensureCleanRepo) {
 // Task parameters:
 //    bumpVersion -> if available will specify new versionName directly and ignores the `bumpType` parameter.
 //    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
+
+apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"
 task releasePrepare(dependsOn: ensureCleanRepo) {
     doLast {
         prepareRelease()

--- a/gradle/clean_release.gradle
+++ b/gradle/clean_release.gradle
@@ -1,0 +1,29 @@
+ext.cleanRelease = {
+    def clean = true
+    def applicationId = android.defaultConfig.applicationId
+
+    String headCommitMessage = grgit.head().shortMessage
+    while (headCommitMessage.contains("[gradle-release-task]")) {
+        clean = false
+        println "Found git commit: $headCommitMessage"
+        if (headCommitMessage.indexOf("$applicationId-") > -1) {
+            def tagName = headCommitMessage.split("$applicationId-")[1]
+            println "Removing the git tag: $tagName"
+            try {
+                grgit.tag.remove {
+                    names = [tagName]
+                }
+            } catch (Exception e) {
+                println "Error while removing git tag:\n $e"
+            }
+        }
+        println "Resetting the git commit permanently!"
+        grgit.reset(commit: "HEAD~1", mode: "hard")
+        headCommitMessage = grgit.head().shortMessage
+
+    }
+    if (clean){
+        println "Repository is already clean"
+    }
+    println "Done!"
+}

--- a/gradle/ensure_clean.gradle
+++ b/gradle/ensure_clean.gradle
@@ -1,0 +1,5 @@
+ext.ensureClean = {
+    if (!grgit.repository.jgit.status().call().clean) {
+        throw new GradleException('Git status is not clean, please stash your changes!')
+    }
+}

--- a/gradle/perform_release.gradle
+++ b/gradle/perform_release.gradle
@@ -1,0 +1,14 @@
+ext.performRelease = {
+    boolean force = false
+    if (project.properties.containsKey("force")) {
+        force = project.properties["force"]
+    }
+    println "Pushing the newest commits to the remote repository (force: $force)"
+    try {
+        grgit.push(force: force, tags: true)
+    } catch (Exception e) {
+        throw new GradleException("Failed to push to the repo,\n" +
+                " you can try using -Pforce=true parameter to force the push, error: \n$e")
+    }
+    println "Done!"
+}

--- a/gradle/prepare_release.gradle
+++ b/gradle/prepare_release.gradle
@@ -1,0 +1,65 @@
+ext.prepareRelease = {
+    def applicationId = android.defaultConfig.applicationId
+    def versionName = android.defaultConfig.versionName
+
+    if (versionName.indexOf("-") > -1) {
+        versionName = versionName.split("-")[0]
+    }
+
+    // Prepare the release commit with the specific tag.
+    String buildText = buildFile.getText()
+    buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$versionName'")
+    buildFile.setText(buildText) //replace the build file's text
+    grgit.add(patterns: ['app/build.gradle'])
+    try {
+        grgit.commit(message: "[gradle-release-task] prepare release $applicationId-$versionName")
+    } catch (Exception e) {
+        throw new GradleException("Failed to commit, error:\n $e")
+    }
+    try {
+        grgit.tag.add {
+            name = versionName
+            message = "Release of $versionName"
+        }
+    } catch (Exception e) {
+        throw new GradleException("Failed to tag the repo, error:\n $e")
+    }
+
+    // Set new version name from input parameters.
+    def newVersionName
+    if (project.properties.containsKey("bumpVersion")) {
+        newVersionName = project.properties["bumpVersion"]
+        println "Bumping the version directly (bumpVersion=$newVersionName)"
+    } else if (project.properties.containsKey("bumpType")) {
+        def (major, minor, patch) = versionName.tokenize('.')
+        switch (bumpType) {
+            case "major":
+                major = major.toInteger() + 1
+                minor = 0
+                patch = 0
+                break
+            case "minor":
+                minor = minor.toInteger() + 1
+                break
+            case "patch":
+                patch = patch.toInteger() + 1
+                break
+        }
+        newVersionName = "$major.$minor.$patch"
+    } else {
+        throw new GradleException('Either bumpType or bumpVersion parameters should be provided')
+    }
+
+    // Prepare for next development iteration.
+    def versionCode = android.defaultConfig.versionCode
+    def newVersionCode = versionCode + 1
+    println "Bumping versionName from $versionName to $newVersionName"
+    println "Bumping versionCode from $versionCode to $newVersionCode"
+    buildText = buildFile.getText()
+    buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName-SNAPSHOT'")
+    buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
+    buildFile.setText(buildText) //replace the build file's text
+    grgit.add(patterns: ['app/build.gradle'])
+    grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
+    println "Done!"
+}

--- a/gradle/prepare_release.gradle
+++ b/gradle/prepare_release.gradle
@@ -10,7 +10,7 @@ ext.prepareRelease = {
     String buildText = buildFile.getText()
     buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$versionName'")
     buildFile.setText(buildText) //replace the build file's text
-    grgit.add(patterns: ['app/build.gradle'])
+    grgit.add(patterns: [project.name + '/build.gradle'])
     try {
         grgit.commit(message: "[gradle-release-task] prepare release $applicationId-$versionName")
     } catch (Exception e) {
@@ -59,7 +59,7 @@ ext.prepareRelease = {
     buildText = buildText.replaceFirst(/versionName(\s+.*)/, "versionName '$newVersionName-SNAPSHOT'")
     buildText = buildText.replaceFirst(/versionCode(\s+.*)/, "versionCode $newVersionCode")
     buildFile.setText(buildText) //replace the build file's text
-    grgit.add(patterns: ['app/build.gradle'])
+    grgit.add(patterns: [project.name + '/build.gradle'])
     grgit.commit(message: "[gradle-release-task] prepare for next development iteration")
     println "Done!"
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'maven-publish'
+    id 'org.ajoberstar.grgit'
 }
 
 apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id 'maven-publish'
 }
 
+apply from: "${rootProject.projectDir}/gradle/prepare_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/clean_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/perform_release.gradle"
+apply from: "${rootProject.projectDir}/gradle/ensure_clean.gradle"
+
 android {
     compileSdk 34
     namespace 'ai.elimu.content_provider.utils'
@@ -52,4 +57,35 @@ publishing {
 
 tasks.named("publishReleasePublicationToMavenLocal") {
     mustRunAfter(":utils:bundleReleaseAar")
+}
+
+tasks.register('ensureCleanRepo') {
+    doLast {
+        ensureClean()
+    }
+}
+
+tasks.register('releaseClean') {
+    dependsOn ensureCleanRepo
+    doLast {
+        cleanRelease()
+    }
+}
+
+// Task parameters:
+//    bumpVersion -> if available will specify new versionName directly and ignores the `bumpType` parameter.
+//    bumpType[major|minor|patch] -> will specify how the version bumping occurs.
+
+tasks.register('releasePrepare') {
+    dependsOn ensureCleanRepo
+    doLast {
+        prepareRelease()
+    }
+}
+
+tasks.register('releasePerform') {
+    dependsOn ensureCleanRepo
+    doLast {
+        performRelease()
+    }
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -49,10 +49,11 @@ publishing {
         }
     }
     repositories {
-        maven {
-            credentials(PasswordCredentials)
-            url "https://maven.pkg.github.com/elimu-ai/content-provider"
-        }
+//        maven {
+//            credentials(PasswordCredentials)
+//            url "https://maven.pkg.github.com/elimu-ai/content-provider"
+//        }
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
### Issue Number
* Resolves #153 

### Purpose
* Move release's related tasks to separate scripts for better reusability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined and automated release preparation process that ensures consistent version updates.
  - Enhanced release management with improved error handling for more reliable versioning in upcoming releases.
  - Added new Gradle tasks for cleaning, preparing, and performing releases, simplifying the release workflow.
  - Implemented a check for a clean Git repository before executing release tasks to prevent errors.
  - Added a new job in the CI/CD pipeline for handling releases of the `utils` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->