### PR TITLE
Increase minSdkVersion to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "ai.elimu.content_provider"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 35
         versionCode 1002029
         versionName "1.2.29-SNAPSHOT"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -8,7 +8,7 @@ android {
     namespace 'ai.elimu.content_provider.utils'
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 34
         versionCode 1002029
         versionName "1.2.29-SNAPSHOT"


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #157 

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Raised the minimum supported Android API level from 24 to 26. This update limits support to devices running API level 26 or newer, so users on older devices might experience compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->