### PR TITLE
Remove snapshot suffix from utils module version name

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId 'ai.elimu.content_provider'
             artifactId 'utils'
-            version '1.2.32-SNAPSHOT'
+            version '1.2.32'
             artifact("${buildDir}/outputs/aar/utils-${version}-release.aar")
         }
     }


### PR DESCRIPTION
Remove snapshot suffix from utils module version name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the artifact version from a development snapshot to a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->