### PR TITLE
Replace usages of deprecated getColor() API

### DIFF
--- a/app/src/main/java/ai/elimu/content_provider/ui/letter_sound/LetterSoundsFragment.kt
+++ b/app/src/main/java/ai/elimu/content_provider/ui/letter_sound/LetterSoundsFragment.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
@@ -73,10 +74,13 @@ class LetterSoundsFragment : Fragment() {
                         processResponseBody(letterSoundGsons)
                     }
                 } else {
-                    // Handle error
-                    Snackbar.make(binding.textLetterSounds, response.toString(), Snackbar.LENGTH_LONG)
-                        .setBackgroundTint(resources.getColor(R.color.deep_orange_darken_4))
-                        .show()
+                    context?.let { context ->
+                        // Handle error
+                        Snackbar.make(binding.textLetterSounds, response.toString(), Snackbar.LENGTH_LONG)
+                            .setBackgroundTint(ContextCompat.getColor(context, R.color.deep_orange_darken_4))
+                            .show()
+                    }
+
                     binding.progressBarLetterSounds.visibility = View.GONE
                 }
             }
@@ -86,10 +90,13 @@ class LetterSoundsFragment : Fragment() {
 
                 Log.e(TAG, "t.getCause():", t.cause)
 
-                // Handle error
-                Snackbar.make(binding.textLetterSounds, t.cause.toString(), Snackbar.LENGTH_LONG)
-                    .setBackgroundTint(resources.getColor(R.color.deep_orange_darken_4))
-                    .show()
+                context?.let { context ->
+                    // Handle error
+                    Snackbar.make(binding.textLetterSounds, t.cause.toString(), Snackbar.LENGTH_LONG)
+                        .setBackgroundTint(ContextCompat.getColor(context, R.color.deep_orange_darken_4))
+                        .show()
+                }
+
                 binding.progressBarLetterSounds.visibility = View.GONE
             }
         })


### PR DESCRIPTION
Replace usages of deprecated `getColor()` API in `LetterSoundsFragment`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message display reliability by ensuring background color is set safely when showing error Snackbars. This enhances app stability during network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->