### PR TITLE
Replace usages of deprecated getColor() API

### DIFF
--- a/app/src/main/java/ai/elimu/content_provider/ui/letter/LettersFragment.kt
+++ b/app/src/main/java/ai/elimu/content_provider/ui/letter/LettersFragment.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
@@ -69,10 +70,12 @@ class LettersFragment : Fragment() {
                         processResponseBody(letterGsons)
                     }
                 } else {
-                    // Handle error
-                    Snackbar.make(binding.textLetters, response.toString(), Snackbar.LENGTH_LONG)
-                        .setBackgroundTint(resources.getColor(R.color.deep_orange_darken_4))
-                        .show()
+                    context?.let { context ->
+                        // Handle error
+                        Snackbar.make(binding.textLetters, response.toString(), Snackbar.LENGTH_LONG)
+                            .setBackgroundTint(ContextCompat.getColor(context, R.color.deep_orange_darken_4))
+                            .show()
+                    }
                     binding.progressBarLetters.visibility = View.GONE
                 }
             }
@@ -82,10 +85,13 @@ class LettersFragment : Fragment() {
 
                 Log.e(TAG, "t.getCause():", t.cause)
 
-                // Handle error
-                Snackbar.make(binding.textLetters, t.cause.toString(), Snackbar.LENGTH_LONG)
-                    .setBackgroundTint(resources.getColor(R.color.deep_orange_darken_4))
-                    .show()
+                context?.let { context ->
+                    // Handle error
+                    Snackbar.make(binding.textLetters, t.cause.toString(), Snackbar.LENGTH_LONG)
+                        .setBackgroundTint(ContextCompat.getColor(context, R.color.deep_orange_darken_4))
+                        .show()
+                }
+
                 binding.progressBarLetters.visibility = View.GONE
             }
         })


### PR DESCRIPTION
Replace usages of deprecated getColor() API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message display reliability by ensuring proper context handling and using updated methods for setting Snackbar background colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->