### PR TITLE
Fix Lint warnings in EmojisFragment

### DIFF
--- a/app/src/main/java/ai/elimu/content_provider/ui/emoji/EmojisFragment.kt
+++ b/app/src/main/java/ai/elimu/content_provider/ui/emoji/EmojisFragment.kt
@@ -139,7 +139,7 @@ class EmojisFragment : Fragment() {
                 val emojis = emojiDao.loadAll()
                 Log.i(javaClass.name, "emojis.size(): " + emojis.size)
                 activity?.runOnUiThread {
-                    binding.textEmojis.text = "emojis.size(): " + emojis.size
+                    binding.textEmojis.text = getString(R.string.emojis_size, emojis.size)
                     Snackbar.make(binding.textEmojis, "emojis.size(): " + emojis.size, Snackbar.LENGTH_LONG)
                         .show()
                     binding.progressBarEmojis.visibility = View.GONE

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="lettersounds_size">letterSounds.size(): %d</string>
     <string name="letters_size">letters.size(): %d</string>
     <string name="images_size">images.size(): %d</string>
+    <string name="emojis_size">emojis.size(): %d</string>
 </resources>


### PR DESCRIPTION
Fix Lint warnings in EmojisFragment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the emoji count display to use a localized string, improving consistency with other collection size displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->