### PR TITLE
Replace usage of deprecated `setDrawerLayout()` API in MainActivity

### DIFF
--- a/app/src/main/java/ai/elimu/content_provider/MainActivity.kt
+++ b/app/src/main/java/ai/elimu/content_provider/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : AppCompatActivity() {
                     R.id.nav_storybooks,
                     R.id.nav_videos
                 )
-                    .setDrawerLayout(drawer)
+                    .setOpenableLayout(drawer)
                     .build()
 
             val navigationView = findViewById<NavigationView>(R.id.nav_view)


### PR DESCRIPTION
Replace usage of deprecated `setDrawerLayout()` API in MainActivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated navigation drawer integration to use the latest recommended method for associating the drawer layout with the navigation component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->